### PR TITLE
M1 mac support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Import GPG key
         id: import_gpg

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,6 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-    - goos: darwin
-      goarch: 'arm64'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Currently Terraform provider is not supported for M1 mac devices (darwin_arm64). Updated the go-releaser to create this binary.