### PR TITLE
chore(docs): Improve provider documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ BUG FIXES:
 ## 1.2.2 (April 20, 2022)
 BUG FIXES:
 - Add M1 MacOS support.
-- Fix dcnm_policy resource destroy and deployement issue when modifying multiple policies.
+- Fix dcnm_policy resource destroy and deployment issue when modifying multiple policies.
 
 ## 1.2.1 (April 6, 2022)
 BUG FIXES:

--- a/website/docs/d/interface.html.markdown
+++ b/website/docs/d/interface.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM interface module
 ---
 
-# dcnm_interface #
+# dcnm_interface
+
 Data source for DCNM interface module
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -22,15 +23,14 @@ data "dcnm_interface" "check" {
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `serial_number` - (Required) Dn for the interface module.
 * `name` - (Required) name of the interface.
 * `type` - (Required) type of the interface. Allowed values are "loopback", "port-channel", "vpc", "sub-interface", "ethernet".
 **NOTE**: Interface type of "sub-interface" is not supported in NDFC 12.
 
-## Common Attribute Reference ##
+## Common Attribute Reference
 
 * `fabric_name` - fabric name under which interface is created.
 * `policy` - policy name for the interface.
@@ -38,7 +38,7 @@ data "dcnm_interface" "check" {
 * `deploy` - deploy flag for the deployment of interface.
 * `switch_name_1` - name of the switch which is associated to the interface.
 
-## Attribute Reference for loopback Interface ##
+## Attribute Reference for loopback Interface
 
 * `vrf` - vrf name for the loopback interface.
 * `ipv4` - ipv4 address for the loopback interface.
@@ -51,7 +51,7 @@ data "dcnm_interface" "check" {
 * `configuration` - configuration for the loopback interface.
 * `description` - description for the loopback interface.
 
-## Attribute Reference for port-channel Interface ##
+## Attribute Reference for port-channel Interface
 
 * `pc_interface` - list of port channel member interface for port-channel interface.
 * `access_vlans` - access vlans for the port-channel interface.
@@ -63,9 +63,9 @@ data "dcnm_interface" "check" {
 * `configuration` - configuration for the port-channel interface.
 * `description` - description for the port-channel interface.
 
-## Attribute Reference for vPC Interface ##
+## Attribute Reference for vPC Interface
 
-* `switch_name_2` - name of the second switch with which vpc is associated. 
+* `switch_name_2` - name of the second switch with which vpc is associated.
 * `vpc_peer1_id` - peer1 port-channel id for the vPC interface.
 * `vpc_peer2_id` - peer2 port-channel id for the vPC interface.
 * `vpc_peer1_interface` - list of peer1 member interface for the vPC interface.
@@ -83,30 +83,30 @@ data "dcnm_interface" "check" {
 * `vpc_peer1_conf` - peer1 configuration for the vPC interface.
 * `vpc_peer2_conf` - peer2 configuration for the vPC interface.
 
-## Attribute Reference for sub-interface Interface ##
+## Attribute Reference for sub-interface Interface
 
 * `subinterface_vlan` - vlan for the sub-interface.
 * `vrf` - vrf for the sub-interface.
 * `ipv4` - ipv4 address for the sub-interface.
 * `ipv6` - ipv6 address for the sub-interface.
-* `ipv6_prefix` - ipv6 prefic for the sub-interface.
+* `ipv6_prefix` - ipv6 prefix for the sub-interface.
 * `ipv4_prefix` - ipv4 prefix for the sub-interface.
 * `subinterface_mtu` - mtu for the sub-interface.
 * `configuration` - configuration for the sub-interface.
 * `description` - description for the sub-interface.
 
-## Attribute Reference for ethernet Interface ##
+## Attribute Reference for ethernet Interface
 
 * `vrf` - vrf name for the ethernet interface.
 * `bpdu_guard_flag` - BPDU flag for the ethernet interface.
 * `port_fast_flag` - port type fast flag for the ethernet interface.
-* `mtu` - mtu for the ethernet interface. 
+* `mtu` - mtu for the ethernet interface.
 * `ethernet_speed` - speed of the ethernet.
 * `allowed_vlans` - allowed vlans for the ethernet interface.
 * `configuration` - configuration for the ethernet.
 * `description` - description for the ethernet.
 * `ipv4` - ipv4 address for the ethernet.
 * `ipv6` - ipv6 address for the ethernet.
-* `ipv6_prefix` - ipv6 prefic for the ethernet.
+* `ipv6_prefix` - ipv6 prefix for the ethernet.
 * `ipv4_prefix` - ipv4 prefix for the ethernet.
 * `access_vlans` -  access vlans for the ethernet interface.

--- a/website/docs/d/interface.html.markdown
+++ b/website/docs/d/interface.html.markdown
@@ -40,9 +40,9 @@ data "dcnm_interface" "check" {
 
 ## Attribute Reference for loopback Interface
 
-* `vrf` - vrf name for the loopback interface.
-* `ipv4` - ipv4 address for the loopback interface.
-* `ipv6` - ipv6 address for the loopback interface.
+* `vrf` - VRF name for the loopback interface.
+* `ipv4` - IPv4 address for the loopback interface.
+* `ipv6` - IPv6 address for the loopback interface.
 * `loopback_tag` - tag for the loopback interface.
 * `loopback_routing_tag` - routing tag for the loopback interface.
 * `loopback_ls_routing` - link state routing protocol for the loopback interface.
@@ -58,7 +58,7 @@ data "dcnm_interface" "check" {
 * `mode` - mode for the port-channel interface.
 * `bpdu_guard_flag` - BPDU flag for the port-channel interface.
 * `port_fast_flag` - port type fast flag for the port-channel interface.
-* `mtu` - mtu for the port-channel interface.
+* `mtu` - MTU for the port-channel interface.
 * `allowed_vlans` - allowed vlans for the port-channel interface.
 * `configuration` - configuration for the port-channel interface.
 * `description` - description for the port-channel interface.
@@ -73,7 +73,7 @@ data "dcnm_interface" "check" {
 * `mode` - mode for the vPC interface.
 * `bpdu_guard_flag` - BPDU flag for the vPC interface.
 * `port_fast_flag` - port type fast flag for the vPC interface.
-* `mtu` - mtu for the vPC interface.
+* `mtu` - MTU for the vPC interface.
 * `vpc_peer1_allowed_vlans` - peer1 allowed vlans for the vPC interface.
 * `vpc_peer2_allowed_vlans` - peer2 allowed vlans for the vPC interface.
 * `vpc_peer1_access_vlans` - peer1 access vlans for the vPC interface.
@@ -85,28 +85,28 @@ data "dcnm_interface" "check" {
 
 ## Attribute Reference for sub-interface Interface
 
-* `subinterface_vlan` - vlan for the sub-interface.
-* `vrf` - vrf for the sub-interface.
-* `ipv4` - ipv4 address for the sub-interface.
-* `ipv6` - ipv6 address for the sub-interface.
-* `ipv6_prefix` - ipv6 prefix for the sub-interface.
-* `ipv4_prefix` - ipv4 prefix for the sub-interface.
-* `subinterface_mtu` - mtu for the sub-interface.
+* `subinterface_vlan` - VLAN for the sub-interface.
+* `vrf` - VRF for the sub-interface.
+* `ipv4` - IPv4 address for the sub-interface.
+* `ipv6` - IPv6 address for the sub-interface.
+* `ipv6_prefix` - IPv6 prefix for the sub-interface.
+* `ipv4_prefix` - IPv4 prefix for the sub-interface.
+* `subinterface_mtu` - MTU for the sub-interface.
 * `configuration` - configuration for the sub-interface.
 * `description` - description for the sub-interface.
 
 ## Attribute Reference for ethernet Interface
 
-* `vrf` - vrf name for the ethernet interface.
+* `vrf` - VRF name for the ethernet interface.
 * `bpdu_guard_flag` - BPDU flag for the ethernet interface.
 * `port_fast_flag` - port type fast flag for the ethernet interface.
-* `mtu` - mtu for the ethernet interface.
+* `mtu` - MTU for the ethernet interface.
 * `ethernet_speed` - speed of the ethernet.
 * `allowed_vlans` - allowed vlans for the ethernet interface.
 * `configuration` - configuration for the ethernet.
 * `description` - description for the ethernet.
-* `ipv4` - ipv4 address for the ethernet.
-* `ipv6` - ipv6 address for the ethernet.
-* `ipv6_prefix` - ipv6 prefix for the ethernet.
-* `ipv4_prefix` - ipv4 prefix for the ethernet.
+* `ipv4` - IPv4 address for the ethernet.
+* `ipv6` - IPv6 address for the ethernet.
+* `ipv6_prefix` - IPv6 prefix for the ethernet.
+* `ipv4_prefix` - IPv4 prefix for the ethernet.
 * `access_vlans` -  access vlans for the ethernet interface.

--- a/website/docs/d/inventory.html.markdown
+++ b/website/docs/d/inventory.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM inventory module
 ---
 
-# dcnm_inventory #
+# dcnm_inventory
+
 Data source for DCNM inventory module
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -20,12 +21,10 @@ data "dcnm_inventory" "check" {
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `fabric_name` - (Required) fabric name under which inventory should be created.
 * `switch_name` - (Required) name of switch.
-
 
 ## Attribute Reference
 

--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM network
 ---
 
-# dcnm_network #
+# dcnm_network
+
 Data source for DCNM network
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -20,12 +21,10 @@ data "dcnm_vrf" "check" {
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `name` - (Required) name of network object.
 * `fabric_name` - (Required) fabric name under which network exists.
-
 
 ## Attribute Reference
 
@@ -33,7 +32,7 @@ data "dcnm_vrf" "check" {
 * `display_name` -  display name for the network object.
 * `description` -  description for the network.
 * `vrf_name` -  name of the vrf which should be associated with the network.
-* `l2_only_flag` -  layer 2 only flag for the network. 
+* `l2_only_flag` -  layer 2 only flag for the network.
 * `vlan_id` -  vlan number for the network.
 * `vlan_name` -  vlan name for the network.
 * `ipv4_gateway` -  ipv4 address of gateway for the network.
@@ -51,14 +50,12 @@ data "dcnm_vrf" "check" {
 * `loopback_id` -  loopback id for the network.
 * `rt_both_flag` -  l2 VNI route-target both enable flag for the network.
 * `trm_enable_flag` -  TRM enable flag for the network.
-* `l3_gateway_flag` -  enable L3 gateway on border flag for the network. 
+* `l3_gateway_flag` -  enable L3 gateway on border flag for the network.
 * `template` -  template name for the network. Default is "Default_VRF_Universal".
 * `extension_template` -  extension Template name for the network. Default is "Default_Network_Extension_Universal".
 * `service_template` -  service template name for the network.
 * `source` -  source for the network.
-
 * `deploy` - deploy flag, used to deploy the network.
-
 * `attachments` - attachment block, have information regarding the switches which should be attached or detached to/from network.
 * `attachments.serial_number` - serial number of the switch.
 * `attachments.vlan_id` - vlan ID for the switch associated with network.

--- a/website/docs/d/network.html.markdown
+++ b/website/docs/d/network.html.markdown
@@ -31,22 +31,22 @@ data "dcnm_vrf" "check" {
 * `id` - Attribute id set to the Dn of the network.
 * `display_name` -  display name for the network object.
 * `description` -  description for the network.
-* `vrf_name` -  name of the vrf which should be associated with the network.
+* `vrf_name` -  name of the VRF which should be associated with the network.
 * `l2_only_flag` -  layer 2 only flag for the network.
-* `vlan_id` -  vlan number for the network.
-* `vlan_name` -  vlan name for the network.
-* `ipv4_gateway` -  ipv4 address of gateway for the network.
-* `ipv6_gateway` -  ipv6 address of gateway for the network.
-* `mtu` -  mtu value for the network.
+* `vlan_id` -  VLAN ID for the network.
+* `vlan_name` -  VLAN name for the network.
+* `ipv4_gateway` -  IPv4 address of gateway for the network.
+* `ipv6_gateway` -  IPv6 address of gateway for the network.
+* `mtu` -  MTU value for the network.
 * `tag` -  tag for the Network.
-* `secondary_gw_1` -  ipv4 secondary gateway 1 for the network.
-* `secondary_gw_2` -  ipv4 secondary gateway 2 for the network.
-* `arp_supp_flag` -  arp suppression flag for the network.
+* `secondary_gw_1` -  IPv4 secondary gateway 1 for the network.
+* `secondary_gw_2` -  IPv4 secondary gateway 2 for the network.
+* `arp_supp_flag` -  ARP suppression flag for the network.
 * `ir_enable_flag` -  ingress replication flag for the network.
 * `mcast_group` -  multicast group address for the network.
-* `dhcp_1` -  ipv4 address of DHCP server 1 for the network.
-* `dhcp_2` -  ipv4 address of DHCP server 2 for the network.
-* `dhcp_vrf` -  vrf name of DHCP server for the network.
+* `dhcp_1` -  IPv4 address of DHCP server 1 for the network.
+* `dhcp_2` -  IPv4 address of DHCP server 2 for the network.
+* `dhcp_vrf` -  VRF name of DHCP server for the network.
 * `loopback_id` -  loopback id for the network.
 * `rt_both_flag` -  l2 VNI route-target both enable flag for the network.
 * `trm_enable_flag` -  TRM enable flag for the network.
@@ -58,7 +58,7 @@ data "dcnm_vrf" "check" {
 * `deploy` - deploy flag, used to deploy the network.
 * `attachments` - attachment block, have information regarding the switches which should be attached or detached to/from network.
 * `attachments.serial_number` - serial number of the switch.
-* `attachments.vlan_id` - vlan ID for the switch associated with network.
+* `attachments.vlan_id` - VLAN ID for the switch associated with network.
 * `attachments.attach` - attach flag for switch.
 * `attachments.switch_ports` - list of port name(i.e. interface names) for switch attachment.
 * `attachments.untagged` -  untagged flag for switch attachment.

--- a/website/docs/d/policy.html.markdown
+++ b/website/docs/d/policy.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM Policy
 ---
 
-# dcnm_policy #
+# dcnm_policy
+
 Data source for DCNM Policy
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -19,12 +20,10 @@ data "dcnm_policy" "example" {
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `policy_id` - (Required) A unique ID identifying a policy.
    NOTE: User can specify only empty string value.
-
 
 ## Attribute Reference
 

--- a/website/docs/d/route_peering.html.markdown
+++ b/website/docs/d/route_peering.html.markdown
@@ -34,16 +34,16 @@ data "dcnm_route_peering" "example"{
 ## Attribute Reference
 
 * `deployment_mode` - (Required) Type of service node.Allowed values are "IntraTenantFW","InterTenantFW","OneArmADC","TwoArmADC","OneArmVNF".
-* `next_hop_ip` - (Optional) Nexthop IPV4 information.NOTE: This object is applicable only when 'deploy_mode' is 'IntraTenantFW'
+* `next_hop_ip` - (Optional) Nexthop IPv4 information.NOTE: This object is applicable only when 'deploy_mode' is 'IntraTenantFW'
 * `option` - (Required) Specifies the type of peering.Allowed values are "StaticPeering","EBGPDynamicPeering","None".
 * `service_networks` - (Required) List of network under which peering will be created.
 * `service_networks.network_name` - (Required) Network name.
-* `reverse_next_hop_ip`- (Optional)  Reverse Nexthop IPV4 information, e.g., 192.169.1.100
+* `reverse_next_hop_ip`- (Optional)  Reverse Nexthop IPv4 information, e.g., 192.169.1.100
 * `service_networks.network_type` - (Required) Type of network.Allowed values are "InsideNetworkFW"(service node = Firewall),"OutsideNetworkFW"(service node = Firewall),"ArmOneADC"(service node = ADC),"ArmTwoADC"(service node = ADC),"ArmOneVNF"(service node= VNF).
 * `service_networks.template_name` - (Required) Name of template.
 * `service_networks.vrf_name` - (Required) VRF name under which network is created.
-* `service_networks.vlan_id` - (Required) VLan Id of network.
-* `service_networks.gateway_ip_address` - (Required) IPV4 gateway information including the mask e.g. 192.168.1.1/24.
+* `service_networks.vlan_id` - (Required) VLAN Id of network.
+* `service_networks.gateway_ip_address` - (Required) IPv4 gateway information including the mask e.g. 192.168.1.1/24.
 * `routes` - (Optional) Routing configuration.
 * `routes.template_name` - (Optional) Template name for routing.
 * `routes.route_parmas` - (Optional) NVPair map for routing.

--- a/website/docs/d/service_node.html.markdown
+++ b/website/docs/d/service_node.html.markdown
@@ -30,7 +30,7 @@ data "dcnm_service_node" "example" {
 
 * `id` - Attribute id is set to the name of the Service Node.
 * `admin_state` - Admin state for the Service Node.
-* `allowed_vlans` - Allowed vlan names of the Service.
+* `allowed_vlans` - Allowed VLAN names of the Service.
 * `attached_fabric` - Name of attached easy fabric to which service node is attached.
 * `attached_switch_interface_name` - Switch interfaces where the service node will be attached.
 * `bpdu_guard_flag` - BPDU flag for the service node.

--- a/website/docs/d/service_node.html.markdown
+++ b/website/docs/d/service_node.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM Service Node
 ---
 
-# dcnm_service_node #
+# dcnm_service_node
+
 Data source for DCNM Service Node
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -20,14 +21,13 @@ data "dcnm_service_node" "example" {
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference 
 
 * `name` - (Required) Name of Object Service Node.
-* `service_fabric` - (Required) Name of external fabric where the service node is located. 
-
+* `service_fabric` - (Required) Name of external fabric where the service node is located.
 
 ## Attribute Reference
+
 * `id` - Attribute id is set to the name of the Service Node.
 * `admin_state` - Admin state for the Service Node.
 * `allowed_vlans` - Allowed vlan names of the Service.
@@ -48,7 +48,6 @@ data "dcnm_service_node" "example" {
 * `policy_id` - ID of the attached policy.
 * `porttype_fast_enabled` - Port-type-fast flag of the service node.
 * `priority` - Priority of the service node.
-
 * `source_fabric_name` - Source fabric name of the service node.
 * `source_if_name` - Source interface name of the service node.
 * `source_serial_number` - Source serial number of the service node.

--- a/website/docs/d/service_policy.html.markdown
+++ b/website/docs/d/service_policy.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM Service Policy
 ---
 
-# dcnm_vrf #
+# dcnm_vrf
+
 Data source for DCNM Service Policy
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -22,15 +23,15 @@ data "dcnm_service_policy" "example" {
 
 ```
 
-## Argument Reference ##
+## Argument Reference
 
 * `policy_name` - (Required) Name of Object Service Policy.
 * `service_fabric` - (Required) Fabric name under which Service Policy should be created.
 * `attached_fabric` - (Required) Attached Fabric name of the Service Policy.
 * `service_node_name` - (Required) Node name of the Service Policy.
 
+## Attribute Reference
 
-## Attribute Reference 
 * `dest_network` - Destination network of the Service Policy.
 * `dest_vrf_name` - Destination VRF name of the Service Policy.
 * `next_hop_ip` - Next hop IP of the Service Policy.

--- a/website/docs/d/template.html.markdown
+++ b/website/docs/d/template.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM Template
 ---
 
-# dcnm_template #
+# dcnm_template
+
 Data source for DCNM Template
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -19,8 +20,7 @@ data "dcnm_template" "ex"{
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `name` - (Required) name of Template.
 * `content` - (Optional) File name or file content.
@@ -30,5 +30,3 @@ data "dcnm_template" "ex"{
 * `template_content_type` - (Optional) Content type of template.
 * `tags` - (Optional) Tag of template.
 * `template_sub_type` - (Optional) Sub type of template.
-
-

--- a/website/docs/d/vrf.html.markdown
+++ b/website/docs/d/vrf.html.markdown
@@ -29,10 +29,10 @@ data "dcnm_vrf" "check" {
 ## Attribute Reference
 
 * `id` - Attribute id set to the Dn of the VRF.
-* `vlan` - Vlan Id for the VRF.
-* `vlan_name` - Vlan name for the VRF.
+* `vlan` - VLAN ID for the VRF.
+* `vlan_name` - VLAN name for the VRF.
 * `description` - Description for the VRF.
-* `intf_description` - Intf description for the VRF.
+* `intf_description` - Interface description for the VRF.
 * `tag` - Tag for the VRF.
 * `max_bgp_path` - Maximum BGP path value for the VRF.
 * `max_ibgp_path` - Maximum iBGP path value for the VRF.
@@ -42,18 +42,18 @@ data "dcnm_vrf" "check" {
 * `loopback_id` - Loopback ip address for the VRF.
 * `mutlicast_group` - Multicast group address for the VRF.
 * `mutlicast_address` - Multicast address for the VRF.
-* `ipv6_link_local_flag` - Ipv6 link local enable flag for the VRF. Allowed values are "true" and "false".
+* `ipv6_link_local_flag` - IPv6 link local enable flag for the VRF. Allowed values are "true" and "false".
 * `trm_bgw_msite_flag` - Trm bgw multisite enable flag for the VRF. Allowed values are "true" and "false".
 * `advertise_host_route` - Advertise host route enable flag for the VRF. Allowed values are "true" and "false".
 * `advertise_default_route` - Advertise default route enable flag for the VRF. Allowed values are "true" and "false".
 * `static_default_route` - Configure static default route enable flag for the VRF. Allowed values are "true" and "false".
 * `template` - Template name for the VRF. Values allowed "Default_VRF_Universal". Default is "Default_VRF_Universal".
-* `mtu` - Mtu value for the VRF. Ranging from 68 to 9216.
+* `mtu` - MTU value for the VRF. Ranging from 68 to 9216.
 * `extension_template` - Extension Template name for the VRF. Values allowed are "Default_VRF_Extension_Universal". Default is "Default_VRF_Extension_Universal".
 * `service_template` - Service template name for the VRF.
 * `source` - Source for the VRF.
 * `deploy` - Deploy flag, used to deploy the VRF. Default value is "true".
 * `attachments` - Attachment block, have information regarding the switches which should be attached or detached to/from VRF.
 * `attachments.serial_number` - Serial number of the switch.
-* `attachments.vlan_id` - Vlan ID for the switch associated with VRF.
+* `attachments.vlan_id` - VLAN ID for the switch associated with VRF.
 * `attachments.attach` - Attach flag for switch.

--- a/website/docs/d/vrf.html.markdown
+++ b/website/docs/d/vrf.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Data source for DCNM VRF
 ---
 
-# dcnm_vrf #
+# dcnm_vrf
+
 Data source for DCNM VRF
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -20,12 +21,10 @@ data "dcnm_vrf" "check" {
 
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `name` - (Required) Name of Object VRF.
 * `fabric_name` - (Required) Fabric name under which VRF exists.
-
 
 ## Attribute Reference
 
@@ -33,7 +32,7 @@ data "dcnm_vrf" "check" {
 * `vlan` - Vlan Id for the VRF.
 * `vlan_name` - Vlan name for the VRF.
 * `description` - Description for the VRF.
-* `intf_description` - Intf desscription for the VRF.
+* `intf_description` - Intf description for the VRF.
 * `tag` - Tag for the VRF.
 * `max_bgp_path` - Maximum BGP path value for the VRF.
 * `max_ibgp_path` - Maximum iBGP path value for the VRF.
@@ -49,12 +48,11 @@ data "dcnm_vrf" "check" {
 * `advertise_default_route` - Advertise default route enable flag for the VRF. Allowed values are "true" and "false".
 * `static_default_route` - Configure static default route enable flag for the VRF. Allowed values are "true" and "false".
 * `template` - Template name for the VRF. Values allowed "Default_VRF_Universal". Default is "Default_VRF_Universal".
-* `mtu` - Mtu value for the VRF. Ranginf from 68 to 9216.
+* `mtu` - Mtu value for the VRF. Ranging from 68 to 9216.
 * `extension_template` - Extension Template name for the VRF. Values allowed are "Default_VRF_Extension_Universal". Default is "Default_VRF_Extension_Universal".
 * `service_template` - Service template name for the VRF.
 * `source` - Source for the VRF.
 * `deploy` - Deploy flag, used to deploy the VRF. Default value is "true".
-
 * `attachments` - Attachment block, have information regarding the switches which should be attached or detached to/from VRF.
 * `attachments.serial_number` - Serial number of the switch.
 * `attachments.vlan_id` - Vlan ID for the switch associated with VRF.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -8,47 +8,17 @@ description: |-
 ---
   
 
-Overview
---------------------------------------------------
-Terraform provider DCNM is a Terraform plugin which will be used to manage the DCNM/NDFC Constructs on the Cisco DCNM/NDFC platform with leveraging advantages of Terraform. DCNM Terraform provider lets users represent the infrastructure as a code and provides a way to enforce state on the infrastructure managed by the Terraform provider. Customers can use this provider to integrate the Terraform configuration with the DevOps pipeline to manage the DCNM/NDFC fabric policies in a more flexible, consistent and reliable way.
+# Overview
 
-Cisco DCNM Provider
-------------
-The Cisco DCNM provider is used to interact with the resources provided by Cisco DCNM and Cisco NDFC. The provider needs to be configured with the proper credentials before it can be used.
+The Cisco Nexus Dashboard Fabric Controller (NDFC, formerly DCNM) Terraform Provider is used to manage constructs on the Cisco DCNM/NDFC platform. It lets users represent the infrastructure as code and provides a way to enforce state on the infrastructure managed by Terraform. Customers can use this provider to integrate the Terraform configuration with their DevOps pipeline to manage the DCNM/NDFC fabric policies in a more flexible, consistent and reliable way.
 
-Authentication
--------------- 
+The provider needs to be configured with the proper credentials before it can be used.
 
-Authentication with user-id and password.  
- example:  
+To learn more about the DCNM/NDFC, visit the [Cisco Nexus Dashboard Fabric Controller product overview](https://www.cisco.com/c/en/us/products/cloud-systems-management/prime-data-center-network-manager/index.html).
 
- ```hcl
+## Example Usage
 
-terraform {
-  required_providers {
-    dcnm = {
-      source = "CiscoDevNet/dcnm"
-    }
-  }
-}
-
-provider "dcnm" {
-  # cisco-dcnm/ndfc user name
-  username = "admin"
-  # cisco-dcnm/ndfc password
-  password = "password"
-  # cisco-dcnm/ndfc url
-  url      = "https://my-cisco-dcnm.com"
-  insecure = true
-  platform = "dcnm"
-}
-
- ```
-
-Example Usage
-------------
 ```hcl
-
 terraform {
   required_providers {
     dcnm = {
@@ -57,7 +27,7 @@ terraform {
   }
 }
 
-#configure provider with your cisco dcnm/ndfc credentials.
+# Configure the provider with your Cisco dcnm/ndfc credentials.
 provider "dcnm" {
   # cisco-dcnm/ndfc user name
   username = "admin"
@@ -72,17 +42,16 @@ provider "dcnm" {
 resource "dcnm_vrf" "test-vrf" {
   fabric_name = "fab1"
   name = "MyVRF"
-  description = "This vrf is created by terraform"
+  description = "This VRF is created by Terraform"
 }
-
 ```
 
-Argument Reference
-------------------
-Following arguments are supported with Cisco DCNM terraform provider.
+## Argument Reference
 
- * `username` - (Required) This is the Cisco DCNM/NDFC username, which is required to authenticate with CISCO DCNM/NDFC.
- * `password` - (Required) Password of the user mentioned in username argument. It is required when you want to use token-based authentication.
- * `url` - (Required) URL for CISCO DCNM/NDFC.
- * `insecure` - (Optional) This determines whether to use insecure HTTP connection or not. Default value is `true`.
- * `platform` - (Optional) NDFC/DCNM Platform information(Nexus-Dashboard/DCNM). Allowed values are "nd" and "dcnm". Default value is "dcnm".
+Following provider configuration arguments are supported within the `provider "dcnm"` block.
+
+* `username` - (Required) This is the Cisco DCNM/NDFC username, which is required to authenticate with CISCO DCNM/NDFC.
+* `password` - (Required) Password of the user mentioned in username argument. It is required when you want to use token-based authentication.
+* `url` - (Required) The URL for Cisco DCNM/NDFC.
+* `insecure` - (Optional) This determines whether to use insecure HTTP connection or not. Default value is `true`.
+* `platform` - (Optional) NDFC/DCNM Platform information (Nexus-Dashboard/DCNM). Allowed values are "nd" or "dcnm". Default value is "dcnm".

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -22,6 +22,7 @@ To learn more about the DCNM/NDFC, visit the [Cisco Nexus Dashboard Fabric Contr
 terraform {
   required_providers {
     dcnm = {
+      # The CiscoDevNet/dcnm provider supports both NDFC and DCNM
       source = "CiscoDevNet/dcnm"
     }
   }

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -158,13 +158,13 @@ resource "dcnm_interface" "second" {
 
 ## Argument Reference for sub-interface Interface ##
 
-* `subinterface_vlan` - (Optional) vlan for the sub-interface.
-* `vrf` - (Optional) vrf for the sub-interface.
-* `ipv4` - (Optional) ipv4 address for the sub-interface.
-* `ipv6` - (Optional) ipv6 address for the sub-interface.
-* `ipv6_prefix` - (Optional) ipv6 prefic for the sub-interface.
-* `ipv4_prefix` - (Optional) ipv4 prefix for the sub-interface.
-* `subinterface_mtu` - (Optional) mtu for the sub-interface.
+* `subinterface_vlan` - (Optional) VLAN for the sub-interface.
+* `vrf` - (Optional) VRF for the sub-interface.
+* `ipv4` - (Optional) IPv4 address for the sub-interface.
+* `ipv6` - (Optional) IPv6 address for the sub-interface.
+* `ipv6_prefix` - (Optional) IPv6 prefix for the sub-interface.
+* `ipv4_prefix` - (Optional) IPv4 prefix for the sub-interface.
+* `subinterface_mtu` - (Optional) MTU for the sub-interface.
 * `configuration` - (Optional) configuration for the sub-interface.
 * `description` - (Optional) description for the sub-interface.
 

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -113,9 +113,9 @@ resource "dcnm_interface" "second" {
 
 ## Argument Reference for loopback Interface ##
 
-* `vrf` - (Optional) vrf name for the loopback interface.
-* `ipv4` - (Optional) ipv4 address for the loopback interface.
-* `ipv6` - (Optional) ipv6 address for the loopback interface.
+* `vrf` - (Optional) VRF name for the loopback interface.
+* `ipv4` - (Optional) IPv4 address for the loopback interface.
+* `ipv6` - (Optional) IPv6 address for the loopback interface.
 * `loopback_tag` - (Optional) tag for the loopback interface.
 * `loopback_routing_tag` - (Optional) routing tag for the loopback interface.
 * `loopback_ls_routing` - (Optional) link state routing protocol for the loopback interface.
@@ -131,8 +131,8 @@ resource "dcnm_interface" "second" {
 * `mode` - (Optional) mode for the port-channel interface. Allowed values are "on", "active" and "passive".
 * `bpdu_guard_flag` - (Optional) BPDU flag for the port-channel interface. Allowed values are "true", "false" and "no".
 * `port_fast_flag` - (Optional) port type fast flag for the port-channel interface.
-* `mtu` - (Optional) mtu for the port-channel interface. Allowed values are "jumbo" and "default". 
-* `allowed_vlans` - (Optional) allowed vlans for the port-channel interface. Allowed values are "none", "all" or vlan ranges(1-200,500-2000,3000) 
+* `mtu` - (Optional) MTU for the port-channel interface. Allowed values are "jumbo" and "default". 
+* `allowed_vlans` - (Optional) allowed vlans for the port-channel interface. Allowed values are "none", "all" or VLAN ranges(1-200,500-2000,3000) 
 * `configuration` - (Optional) configuration for the port-channel interface.
 * `description` - (Optional) description for the port-channel interface.
 
@@ -146,9 +146,9 @@ resource "dcnm_interface" "second" {
 * `mode` - (Optional)  mode for the vPC interface. Allowed values are "on", "active" and "passive".
 * `bpdu_guard_flag` - (Optional) BPDU flag for the vPC interface. Allowed values are "true", "false" and "no".
 * `port_fast_flag` - (Optional) port type fast flag for the vPC interface.
-* `mtu` - (Optional) mtu for the vPC interface. Allowed values are "jumbo" and "default".
-* `vpc_peer1_allowed_vlans` - (Optional) peer1 allowed vlans for the vPC interface. Allowed values are "none", "all" or vlan ranges(1-200,500-2000,3000) 
-* `vpc_peer2_allowed_vlans` - (Optional) peer2 allowed vlans for the vPC interface. Allowed values are "none", "all" or vlan ranges(1-200,500-2000,3000) 
+* `mtu` - (Optional) MTU for the vPC interface. Allowed values are "jumbo" and "default".
+* `vpc_peer1_allowed_vlans` - (Optional) peer1 allowed vlans for the vPC interface. Allowed values are "none", "all" or VLAN ranges(1-200,500-2000,3000) 
+* `vpc_peer2_allowed_vlans` - (Optional) peer2 allowed vlans for the vPC interface. Allowed values are "none", "all" or VLAN ranges(1-200,500-2000,3000) 
 * `vpc_peer1_access_vlans` - (Optional) peer1 access vlans for the vPC interface.
 * `vpc_peer2_access_vlans` - (Optional) peer2 access vlans for the vPC interface.
 * `vpc_peer1_desc` - (Optional) peer1 description for the vPC interface.
@@ -170,19 +170,19 @@ resource "dcnm_interface" "second" {
 
 ## Argument Reference for ethernet Interface ##
 
-* `vrf` - (Optional) vrf name for the ethernet interface.
+* `vrf` - (Optional) VRF name for the ethernet interface.
 * `bpdu_guard_flag` - (Optional) BPDU flag for the ethernet interface. Allowed values are "true", "false" and "no".
 * `port_fast_flag` - (Optional) port type fast flag for the ethernet interface.
-* `mtu` - (Optional) mtu for the ethernet interface. Allowed values are "jumbo" and "default". If `policy` is configured as "epl_routed_intf" or "int_routed_host_11_1", then allowed value range is from 576 to 9216.
+* `mtu` - (Optional) MTU for the ethernet interface. Allowed values are "jumbo" and "default". If `policy` is configured as "epl_routed_intf" or "int_routed_host_11_1", then allowed value range is from 576 to 9216.
 * `ethernet_speed` - (Optional) speed of the ethernet. Allowed values are "Auto", "100Mb", "1Gb", "10Gb", "25Gb",	"40Gb" and "100Gb".
-* `allowed_vlans` - (Optional) allowed vlans for the ethernet interface. Allowed values are "none", "all" or vlan ranges(1-200,500-2000,3000)
+* `allowed_vlans` - (Optional) allowed vlans for the ethernet interface. Allowed values are "none", "all" or VLAN ranges(1-200,500-2000,3000)
 * `configuration` - (Optional) configuration for the ethernet.
 * `description` - (Optional) description for the ethernet.
-* `ipv4` - (Optional) ipv4 address for the ethernet.
-* `ipv6` - (Optional) ipv6 address for the ethernet.
-* `ipv6_prefix` - (Optional) ipv6 prefix for the ethernet.
-* `ipv4_prefix` - (Optional) ipv4 prefix for the ethernet.
-* `access_vlans` - (Optional) access vlans for the ethernet interface.
+* `ipv4` - (Optional) IPv4 address for the ethernet.
+* `ipv6` - (Optional) IPv6 address for the ethernet.
+* `ipv6_prefix` - (Optional) IPv6 prefix for the ethernet.
+* `ipv4_prefix` - (Optional) IPv4 prefix for the ethernet.
+* `access_vlans` - (Optional) access VLANs for the ethernet interface.
 
 
 ## Attribute Reference

--- a/website/docs/r/inventory.html.markdown
+++ b/website/docs/r/inventory.html.markdown
@@ -6,13 +6,13 @@ description: |-
   Manages DCNM inventory modules
 ---
 
-# dcnm_inventory #
+# dcnm_inventory
+
 Manages DCNM inventory modules
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
-
 resource "dcnm_inventory" "first" {
   fabric_name   = "fab2"
   username      = "username for DCNM switches"
@@ -34,11 +34,9 @@ resource "dcnm_inventory" "first" {
     role = "leaf"
   }
 }
-
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `fabric_name` - (Required) Fabric name under which inventory should be created.
 * `username` - (Required) Username for the the switch.
@@ -67,11 +65,10 @@ resource "dcnm_inventory" "first" {
 * `switch_config.model` - Model name of the switch.
 * `switch_config.mode` - Mode of the switch.
 
-## Importing ##
+## Importing
 
 An existing switch inventory can be [imported][docs-import] into this resource via its fabric and name, using the following command:
 [docs-import]: https://www.terraform.io/docs/import/index.html
-
 
 ```
 terraform import dcnm_inventory.example <fabric_name>:<switch_name>

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -73,26 +73,26 @@ resource "dcnm_network" "first" {
 
 * `display_name` - (Optional) display name for the network object. If not mentioned, then `name` will be considered as `display_name`.
 * `description` - (Optional) description for the network.
-* `vrf_name` - (Optional) name of the vrf which should be associated with the network. If not given then will be configured as "NA" with `l2_only_flag` as "true".
-* `vlan_id` - (Optional) vlan number for the network.
-* `vlan_name` - (Optional) vlan name for the network.
-* `ipv4_gateway` - (Optional) ipv4 address of gateway for the network.
-* `ipv6_gateway` - (Optional) ipv6 address of gateway for the network.
-* `mtu` - (Optional) mtu value for the network. Ranging from 68 to 9216.
+* `vrf_name` - (Optional) name of the VRF which should be associated with the network. If not given then will be configured as "NA" with `l2_only_flag` as "true".
+* `vlan_id` - (Optional) VLAN number for the network.
+* `vlan_name` - (Optional) VLAN name for the network.
+* `ipv4_gateway` - (Optional) IPv4 address of gateway for the network.
+* `ipv6_gateway` - (Optional) IPv6 address of gateway for the network.
+* `mtu` - (Optional) MTU value for the network. Ranging from 68 to 9216.
 * `tag` - (Optional) tag for the Network. Ranging from 0 to 4294967295.
-* `secondary_gw_1` - (Optional) ipv4 secondary gateway 1 for the network.
-* `secondary_gw_2` - (Optional) ipv4 secondary gateway 2 for the network.
-* `secondary_gw_3` - (Optional) ipv4 secondary gateway 3 for the network.
-* `secondary_gw_4` - (Optional) ipv4 secondary gateway 4 for the network.
-* `arp_supp_flag` - (Optional) arp suppression flag for the network.
+* `secondary_gw_1` - (Optional) IPv4 secondary gateway 1 for the network.
+* `secondary_gw_2` - (Optional) IPv4 secondary gateway 2 for the network.
+* `secondary_gw_3` - (Optional) IPv4 secondary gateway 3 for the network.
+* `secondary_gw_4` - (Optional) IPv4 secondary gateway 4 for the network.
+* `arp_supp_flag` - (Optional) ARP suppression flag for the network.
 * `ir_enable_flag` - (Optional) ingress replication flag for the network.
 * `mcast_group` - (Optional) multicast group address for the network (not applicable for fabrics of type MFD).
-* `dhcp_1` - (Optional) ipv4 address of DHCP server 1 for the network.
-* `dhcp_2` - (Optional) ipv4 address of DHCP server 2 for the network.
-* `dhcp_3` - (Optional) ipv4 address of DHCP server 3 for the network.
-* `dhcp_vrf` - (Optional) vrf name of DHCP server for the network.
-* `dhcp_vrf_2` - (Optional) vrf name of DHCP server 2 for the network.
-* `dhcp_vrf_3` - (Optional) vrf name of DHCP server 3 for the network.
+* `dhcp_1` - (Optional) IPv4 address of DHCP server 1 for the network.
+* `dhcp_2` - (Optional) IPv4 address of DHCP server 2 for the network.
+* `dhcp_3` - (Optional) IPv4 address of DHCP server 3 for the network.
+* `dhcp_vrf` - (Optional) VRF name of DHCP server for the network.
+* `dhcp_vrf_2` - (Optional) VRF name of DHCP server 2 for the network.
+* `dhcp_vrf_3` - (Optional) VRF name of DHCP server 3 for the network.
 * `loopback_id` - (Optional) loopback id for the network. Ranging from 0 to 1023.
 * `rt_both_flag` - (Optional) l2 VNI route-target both enable flag for the network.
 * `trm_enable_flag` - (Optional) TRM enable flag for the network.
@@ -111,9 +111,9 @@ resource "dcnm_network" "first" {
 
 * `attachments` - (Optional) attachment block, have information regarding the switches which should be attached or detached to/from network. If `deploy` is "true", then at least one attachment must be configured.
 * `attachments.serial_number` - (Required) serial number of the switch.
-* `attachments.vlan_id` - (Optional) vlan ID for the switch associated with network. If not mentioned then network's default vlan id will be used for attachment.
+* `attachments.vlan_id` - (Optional) VLAN ID for the switch associated with network. If not mentioned then network's default VLAN ID will be used for attachment.
 * `attachments.attach` - (Optional) attach flag for switch. Default value is "true".
-* `attachments.dot1_qvlan` - (Optional) dot1 qvlan for switch attachment.
+* `attachments.dot1_qvlan` - (Optional) dot1q VLAN for switch attachment.
 * `attachments.switch_ports` - (Optional) list of port names (i.e. interface names) for switch attachment.
 * `attachments.untagged` - (Optional) untagged flag for switch attachment.
 * `attachments.free_form_config` - (Optional) free form configuration for the switch attachment.

--- a/website/docs/r/network.html.markdown
+++ b/website/docs/r/network.html.markdown
@@ -109,12 +109,12 @@ resource "dcnm_network" "first" {
 * `deploy` - (Optional) deploy flag, used to deploy the network. Default value is "true".
 * `deploy_timeout` - (Optional) deployment timeout, used as the limiter for the deployment status check for network resource. It is in the unit of seconds and default value is "300".
 
-* `attachments` - (Optional) attachment block, have information regarding the switches which should be attached or detached to/from network. If `deploy` is "true", then atleast one attachment must be configured.
+* `attachments` - (Optional) attachment block, have information regarding the switches which should be attached or detached to/from network. If `deploy` is "true", then at least one attachment must be configured.
 * `attachments.serial_number` - (Required) serial number of the switch.
 * `attachments.vlan_id` - (Optional) vlan ID for the switch associated with network. If not mentioned then network's default vlan id will be used for attachment.
 * `attachments.attach` - (Optional) attach flag for switch. Default value is "true".
 * `attachments.dot1_qvlan` - (Optional) dot1 qvlan for switch attachment.
-* `attachments.switch_ports` - (Optional) list of port name(i.e. interface names) for switch attachment.
+* `attachments.switch_ports` - (Optional) list of port names (i.e. interface names) for switch attachment.
 * `attachments.untagged` - (Optional) untagged flag for switch attachment.
 * `attachments.free_form_config` - (Optional) free form configuration for the switch attachment.
 * `attachments.extension_values` - (Optional) extension values for switch attachment.

--- a/website/docs/r/rest.html.markdown
+++ b/website/docs/r/rest.html.markdown
@@ -6,13 +6,13 @@ description: |-
   Manages DCNM rest modules
 ---
 
-# dcnm_rest #
+# dcnm_rest
+
 Manages DCNM rest modules
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
-
 resource "dcnm_rest" "first" {
   path    = "/rest/top-down/fabrics/fab2/networks/import"
   payload = <<EOF
@@ -35,11 +35,9 @@ resource "dcnm_rest" "template_validate" {
   payload = file("payload.txt")
   payload_type = "text"
 }
-
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `path` - (Required) DCNM REST endpoint, where the data is being sent.
 * `method` - (Optional) HTTP method. Allowed values are "GET", "PUT", "POST", "DELETE".

--- a/website/docs/r/route_peering.html.markdown
+++ b/website/docs/r/route_peering.html.markdown
@@ -183,16 +183,16 @@ resource "dcnm_route_peering" "adc3"{
 * `attached_fabric` - (Required) Name of the target fabric for route peering operations.
 * `deployment_mode` - (Required) Type of service node. Allowed values are "IntraTenantFW", "InterTenantFW", "OneArmADC", "TwoArmADC", "OneArmVNF".
 * `service_fabric` - (Required) Name of the target fabric for route peering operations.
-* `next_hop_ip` - (Optional) Nexthop IPV4 information. NOTE: This object is applicable only when 'deploy_mode' is 'IntraTenantFW'
+* `next_hop_ip` - (Optional) Nexthop IPv4 information. NOTE: This object is applicable only when 'deploy_mode' is 'IntraTenantFW'
 * `option` - (Required) Specifies the type of peering. Allowed values are "StaticPeering", "EBGPDynamicPeering", "None".
 * `service_networks` - (Required) List of network under which peering will be created.
 * `service_networks.network_name` - (Required) Network name.
-* `reverse_next_hop_ip`- (Optional)  Reverse Nexthop IPV4 information, e.g., 192.169.1.100.
+* `reverse_next_hop_ip`- (Optional)  Reverse Nexthop IPv4 information, e.g., 192.169.1.100.
 * `service_networks.network_type` - (Required) Type of network. Allowed values are "InsideNetworkFW" (service node = Firewall), "OutsideNetworkFW" (service node = Firewall), "ArmOneADC" (service node = ADC), "ArmTwoADC" (service node = ADC), "ArmOneVNF" (service node= VNF).
 * `service_networks.template_name` - (Required) Name of template.
 * `service_networks.vrf_name` - (Required) VRF name under which network is created.
 * `service_networks.vlan_id` - (Required) VLAN Id of network.
-* `service_networks.gateway_ip_address` - (Required) IPV4 gateway information including the mask e.g. 192.168.1.1/24.
+* `service_networks.gateway_ip_address` - (Required) IPv4 gateway information including the mask e.g. 192.168.1.1/24.
 * `routes` - (Optional) Routing configuration.
 * `routes.template_name` - (Optional) Template name for routing.
 * `routes.route_parmas` - (Optional) NVPair map for routing. The value for predefined route parameters depends upon deployment mode.

--- a/website/docs/r/route_peering.html.markdown
+++ b/website/docs/r/route_peering.html.markdown
@@ -181,26 +181,26 @@ resource "dcnm_route_peering" "adc3"{
 
 * `name` - (Required) Name of route peering.
 * `attached_fabric` - (Required) Name of the target fabric for route peering operations.
-* `deployment_mode` - (Required) Type of service node.Allowed values are "IntraTenantFW","InterTenantFW","OneArmADC","TwoArmADC","OneArmVNF".
+* `deployment_mode` - (Required) Type of service node. Allowed values are "IntraTenantFW", "InterTenantFW", "OneArmADC", "TwoArmADC", "OneArmVNF".
 * `service_fabric` - (Required) Name of the target fabric for route peering operations.
-* `next_hop_ip` - (Optional) Nexthop IPV4 information.NOTE: This object is applicable only when 'deploy_mode' is 'IntraTenantFW'
-* `option` - (Required) Specifies the type of peering.Allowed values are "StaticPeering","EBGPDynamicPeering","None".
+* `next_hop_ip` - (Optional) Nexthop IPV4 information. NOTE: This object is applicable only when 'deploy_mode' is 'IntraTenantFW'
+* `option` - (Required) Specifies the type of peering. Allowed values are "StaticPeering", "EBGPDynamicPeering", "None".
 * `service_networks` - (Required) List of network under which peering will be created.
 * `service_networks.network_name` - (Required) Network name.
 * `reverse_next_hop_ip`- (Optional)  Reverse Nexthop IPV4 information, e.g., 192.169.1.100.
-* `service_networks.network_type` - (Required) Type of network.Allowed values are "InsideNetworkFW"(service node = Firewall),"OutsideNetworkFW"(service node = Firewall),"ArmOneADC"(service node = ADC),"ArmTwoADC"(service node = ADC),"ArmOneVNF"(service node= VNF).
+* `service_networks.network_type` - (Required) Type of network. Allowed values are "InsideNetworkFW" (service node = Firewall), "OutsideNetworkFW" (service node = Firewall), "ArmOneADC" (service node = ADC), "ArmTwoADC" (service node = ADC), "ArmOneVNF" (service node= VNF).
 * `service_networks.template_name` - (Required) Name of template.
 * `service_networks.vrf_name` - (Required) VRF name under which network is created.
-* `service_networks.vlan_id` - (Required) VLan Id of network.
+* `service_networks.vlan_id` - (Required) VLAN Id of network.
 * `service_networks.gateway_ip_address` - (Required) IPV4 gateway information including the mask e.g. 192.168.1.1/24.
 * `routes` - (Optional) Routing configuration.
 * `routes.template_name` - (Optional) Template name for routing.
-* `routes.route_parmas` - (Optional) NVPair map for routing. The value for predefined route parameters depens upon deployment mode.
+* `routes.route_parmas` - (Optional) NVPair map for routing. The value for predefined route parameters depends upon deployment mode.
 * `routes.vrf_name` - (Optional) VRF name for routing.
 * `deploy` - (Optional) A flag specifying if a route peering is to be deployed on the switches. Default value is "true".
 * `deploy_timeout` - (Optional) Timeout seconds for deployment. Default value is 300s.
 * `service_node_name`- (Required) Name of service node under which route peering is will be created.
-* `service_node_type` - (Required) Type of service node.Allowed values are "Firewall","VNF","ADC".
+* `service_node_type` - (Required) Type of service node. Allowed values are "Firewall", "VNF", "ADC".
 
 ## Attribute Reference
 

--- a/website/docs/r/service_node.html.markdown
+++ b/website/docs/r/service_node.html.markdown
@@ -38,7 +38,7 @@ resource "dcnm_service_node" "example" {
 ## Argument Reference
 
 - `name` - (Required) Name of Object Service Node.
-- `node_type` - (Required) Name of the service node type. Aloowed values are "Firewall", "ADC" and "VNF".
+- `node_type` - (Required) Name of the service node type. Allowed values are "Firewall", "ADC" and "VNF".
 - `service_fabric` - (Required) Name of external fabric where the service node is located.
 - `attached_fabric` - (Required) Name of attached easy fabric to which service node is attached.
 - `attached_switch_interface_name` - (Required) Switch interfaces where the service node will be attached.
@@ -46,8 +46,8 @@ resource "dcnm_service_node" "example" {
 - `link_template_name` - (Optional) Link template name of the service node.
 - `switches` - (Required) List of serial Numbers of the switch where service node will be added.
 - `admin_state` - (Optional) Admin state for the Service Node. Allowed values are true and false. Default value is true.
-- `allowed_vlans` - (Optional) Allowed vlan names of the Service. Default value is "none".
-- `bpdu_guard_flag` - (Optional) BPDU flag for the service node. Allowed values are "true" ,"false" and "no". Default value is "no".
+- `allowed_vlans` - (Optional) Allowed VLAN names of the Service. Default value is "none".
+- `bpdu_guard_flag` - (Optional) BPDU flag for the service node. Allowed values are "true", "false" and "no". Default value is "no".
 - `form_factor` - (Optional) Form factor of the service node. Allowed values are "Physical" and "Virtual". Default value is "Virtual".
 - `mtu` - (Optional) MTU of the service node. Default value is "jumbo".
 - `policy_description` - (Optional) Description of the attached policy.

--- a/website/docs/r/template.html.markdown
+++ b/website/docs/r/template.html.markdown
@@ -6,10 +6,11 @@ description: |-
   Manages DCNM Template
 ---
 
-# dcnm_template #
+# dcnm_template
+
 Manages DCNM Template
 
-## Example Usage ##
+## Example Usage
 
 ```hcl
 
@@ -63,12 +64,9 @@ template_content_type="TEMPLATE_CLI"
 tags="tag1"
 template_sub_type="VXLAN"
 }
-
-
 ```
 
-
-## Argument Reference ##
+## Argument Reference
 
 * `name` - (Required) Name of Template.
 * `content` - (Required) Content of file or file name.
@@ -79,8 +77,6 @@ template_sub_type="VXLAN"
 * `tags` - (Optional) Tag of template.
 * `template_sub_type` - (Optional) Sub type of template.
 
-
-
 ## Attribute Reference
 
 The only attribute that this resource exports is the `id`, which is set to the
@@ -90,7 +86,6 @@ Dn of the template.
 
 An existing Template can be [imported][docs-import] into this resource via template name, using the following command:
 [docs-import]: https://www.terraform.io/docs/import/index.html
-
 
 ```
 terraform import dcnm_template.example <template_name>

--- a/website/docs/r/vrf.html.markdown
+++ b/website/docs/r/vrf.html.markdown
@@ -64,8 +64,8 @@ resource "dcnm_vrf" "first" {
 
 <strong>Note: </strong> For auto-generation of segment-id while creating multiple VRFs in the same plan, Use the depends on functionality of terraform to avoid any segment-id conflicts.
 
-- `vlan` - (Optional) Vlan Id for the VRF.
-- `vlan_name` - (Optional) Vlan name for the VRF.
+- `vlan` - (Optional) VLAN Id for the VRF.
+- `vlan_name` - (Optional) VLAN name for the VRF.
 - `description` - (Optional) Description for the VRF.
 - `intf_description` - (Optional) Intf description for the VRF.
 - `tag` - (Optional) Tag for the VRF. Ranging from 0 to 4294967295.
@@ -77,7 +77,7 @@ resource "dcnm_vrf" "first" {
 - `loopback_id` - (Optional) Loopback ip address for the VRF. Ranging from 0 to 1023.
 - `mutlicast_group` - (Optional) Multicast group address for the VRF. Ranging from 224.0.0.0/4 to 239.255.255.255/4.
 - `mutlicast_address` - (Optional) Multicast address for the VRF.
-- `ipv6_link_local_flag` - (Optional) Ipv6 link local enable flag for the VRF. Allowed values are "true" and "false".
+- `ipv6_link_local_flag` - (Optional) IPv6 link local enable flag for the VRF. Allowed values are "true" and "false".
 - `trm_bgw_msite_flag` - (Optional) Trm bgw multisite enable flag for the VRF. Allowed values are "true" and "false".
 - `advertise_host_route` - (Optional) Advertise host route enable flag for the VRF. Allowed values are "true" and "false".
 - `advertise_default_route` - (Optional) Advertise default route enable flag for the VRF. Allowed values are "true" and "false".
@@ -91,15 +91,15 @@ resource "dcnm_vrf" "first" {
 - `deploy` - (Optional) Deploy flag, used to deploy the VRF. Default value is "true".
 - `deploy_timeout` - (Optional) Deployment timeout, used as the limiter for the deployment status check for VRF resource. It is in the unit of seconds and default value is "300".
 
-- `attachments` - (Optional) Attachment Block, have information regarding the switches which should be attached or detached to/from VRF. If `deploy` is "true", then atleast one attachment must be configured.
+- `attachments` - (Optional) Attachment Block, have information regarding the switches which should be attached or detached to/from VRF. If `deploy` is "true", then at least one attachment must be configured.
 - `attachments.serial_number` - (Required) Serial number of the switch.
-- `attachments.vlan_id` - (Optional) Vlan ID for the switch associated with VRF. If not mentioned then VRF's default vlan id will be used for attachment.
+- `attachments.vlan_id` - (Optional) VLAN ID for the switch associated with VRF. If not mentioned then VRF's default vlan id will be used for attachment.
 - `attachments.attach` - (Optional) Attach flag for switch. Default value is "true".
 - `attachments.free_form_config` - (Optional) Free form configuration for the switch attachment.
 - `attachments.extension_values` - (Optional) Extension values for switch attachment.
 - `attachments.loopback_id` - (Optional) Loopback id for the switch attachment.
-- `attachments.loopback_ipv4` - (Optional) Loopback ipv4 address for the switch attachment.
-- `attachments.loopback_ipv6` - (Optional) Loopback ipv6 address for the switch attachment.
+- `attachments.loopback_ipv4` - (Optional) Loopback IPv4 address for the switch attachment.
+- `attachments.loopback_ipv6` - (Optional) Loopback IPv6 address for the switch attachment.
 - `attachments.vrf_lite` - (Optional) VRF lite for the switch attachment.
 - `attachments.vrf_lite.peer_vrf_name` - (Required) Name of vrf lite for the switch attachment.
 - `attachments.vrf_lite.interface_name` - (Required) Interface name of external edge router for the switch attachment.
@@ -107,8 +107,8 @@ resource "dcnm_vrf" "first" {
 - `attachments.vrf_lite.ip_mask` - (Optional) Ip mask of vrf lite for the switch attachment.
 - `attachments.vrf_lite.neighbor_ip` - (Optional) Neighbor ip of vrf lite for the switch attachment.
 - `attachments.vrf_lite.neighbor_asn` - (Optional) Neighbor asn of vrf lite for the switch attachment.
-- `attachments.vrf_lite.ipv6_mask` - (Optional) Ipv6 mask of vrf lite for the switch attachment.
-- `attachments.vrf_lite.ipv6_neighbor` - (Optional) Ipv6 neighbor of vrf lite for the switch attachment.
+- `attachments.vrf_lite.ipv6_mask` - (Optional) IPv6 mask of vrf lite for the switch attachment.
+- `attachments.vrf_lite.ipv6_neighbor` - (Optional) IPv6 neighbor of vrf lite for the switch attachment.
 - `attachments.vrf_lite.auto_vrf_lite_flag` - (Optional) Auto vrf lite flag of vrf lite for the switch attachment.
 
 ## Attribute Reference

--- a/website/docs/r/vrf.html.markdown
+++ b/website/docs/r/vrf.html.markdown
@@ -64,7 +64,7 @@ resource "dcnm_vrf" "first" {
 
 <strong>Note: </strong> For auto-generation of segment-id while creating multiple VRFs in the same plan, Use the depends on functionality of terraform to avoid any segment-id conflicts.
 
-- `vlan` - (Optional) VLAN Id for the VRF.
+- `vlan` - (Optional) VLAN ID for the VRF.
 - `vlan_name` - (Optional) VLAN name for the VRF.
 - `description` - (Optional) Description for the VRF.
 - `intf_description` - (Optional) Intf description for the VRF.
@@ -83,7 +83,7 @@ resource "dcnm_vrf" "first" {
 - `advertise_default_route` - (Optional) Advertise default route enable flag for the VRF. Allowed values are "true" and "false".
 - `static_default_route` - (Optional) Configure static default route enable flag for the VRF. Allowed values are "true" and "false".
 - `template` - (Optional) Template name for the VRF. Values allowed "Default_VRF_Universal". Default is "Default_VRF_Universal".
-- `mtu` - (Optional) Mtu value for the VRF. Ranging from 68 to 9216.
+- `mtu` - (Optional) MTU value for the VRF. Ranging from 68 to 9216.
 - `extension_template` - (Optional) Extension Template name for the VRF. Values allowed are "Default_VRF_Extension_Universal". Default is "Default_VRF_Extension_Universal".
 - `service_template` - (Optional) Service template name for the VRF.
 - `source` - (Optional) Source for the VRF.
@@ -93,7 +93,7 @@ resource "dcnm_vrf" "first" {
 
 - `attachments` - (Optional) Attachment Block, have information regarding the switches which should be attached or detached to/from VRF. If `deploy` is "true", then at least one attachment must be configured.
 - `attachments.serial_number` - (Required) Serial number of the switch.
-- `attachments.vlan_id` - (Optional) VLAN ID for the switch associated with VRF. If not mentioned then VRF's default vlan id will be used for attachment.
+- `attachments.vlan_id` - (Optional) VLAN ID for the switch associated with VRF. If not mentioned then VRF's default VLAN ID will be used for attachment.
 - `attachments.attach` - (Optional) Attach flag for switch. Default value is "true".
 - `attachments.free_form_config` - (Optional) Free form configuration for the switch attachment.
 - `attachments.extension_values` - (Optional) Extension values for switch attachment.
@@ -101,15 +101,15 @@ resource "dcnm_vrf" "first" {
 - `attachments.loopback_ipv4` - (Optional) Loopback IPv4 address for the switch attachment.
 - `attachments.loopback_ipv6` - (Optional) Loopback IPv6 address for the switch attachment.
 - `attachments.vrf_lite` - (Optional) VRF lite for the switch attachment.
-- `attachments.vrf_lite.peer_vrf_name` - (Required) Name of vrf lite for the switch attachment.
+- `attachments.vrf_lite.peer_vrf_name` - (Required) Name of VRF lite for the switch attachment.
 - `attachments.vrf_lite.interface_name` - (Required) Interface name of external edge router for the switch attachment.
-- `attachments.vrf_lite.dotq_id` - (Optional) Dotq id of vrf lite for the switch attachment.
-- `attachments.vrf_lite.ip_mask` - (Optional) Ip mask of vrf lite for the switch attachment.
-- `attachments.vrf_lite.neighbor_ip` - (Optional) Neighbor ip of vrf lite for the switch attachment.
-- `attachments.vrf_lite.neighbor_asn` - (Optional) Neighbor asn of vrf lite for the switch attachment.
-- `attachments.vrf_lite.ipv6_mask` - (Optional) IPv6 mask of vrf lite for the switch attachment.
-- `attachments.vrf_lite.ipv6_neighbor` - (Optional) IPv6 neighbor of vrf lite for the switch attachment.
-- `attachments.vrf_lite.auto_vrf_lite_flag` - (Optional) Auto vrf lite flag of vrf lite for the switch attachment.
+- `attachments.vrf_lite.dotq_id` - (Optional) Dotq id of VRF lite for the switch attachment.
+- `attachments.vrf_lite.ip_mask` - (Optional) Ip mask of VRF lite for the switch attachment.
+- `attachments.vrf_lite.neighbor_ip` - (Optional) Neighbor ip of VRF lite for the switch attachment.
+- `attachments.vrf_lite.neighbor_asn` - (Optional) Neighbor asn of VRF lite for the switch attachment.
+- `attachments.vrf_lite.ipv6_mask` - (Optional) IPv6 mask of VRF lite for the switch attachment.
+- `attachments.vrf_lite.ipv6_neighbor` - (Optional) IPv6 neighbor of VRF lite for the switch attachment.
+- `attachments.vrf_lite.auto_vrf_lite_flag` - (Optional) Auto VRF lite flag of VRF lite for the switch attachment.
 
 ## Attribute Reference
 


### PR DESCRIPTION
This PR intends to improve the documentation on  the published Terraform Provider docs here:

https://registry.terraform.io/providers/CiscoDevNet/dcnm/latest/docs

* Improvement to the main overview page
    * this is the first entry point to end-users and should help market the purpose and value of the provider, while being a succient as possible. I reduced the authentication HCL and example HCL into one, as they were duplicative, which reduces what the user needs to read to start up.
    * I would definitely give the index overview page a good review to ensure I linked to the DCNM marketing page properly, and the wording make sense. It has been simplified intentionally, but welcome feedback.
* Handful of typos fixed
* Improved Markdown formatting for consistency (using a Markdown linter, and according to some modern Markdown best practices, which should in most cases not change the format, but make them visually display well via either GitHub or when generated on HashiCorp's web site)

Some of the elements in the resources looks like perhaps they were autogenerated, as a number had duplicate typos, so I'm not sure if this is a good fix or not but welcome the team to accept it or not + learn more.

Keep up the great work Cisco team!

- Adam, Cisco CX