### PR TITLE
Fixing inventory resource

### DIFF
--- a/examples/inventory/main.tf
+++ b/examples/inventory/main.tf
@@ -18,7 +18,7 @@ resource "dcnm_inventory" "first" {
   username        = ""
   password        = ""
   preserve_config = "false"
-  config_timeout  = 10
+  config_timeout  = 300
   switch_config {
     ip   = ""
     role = "leaf"

--- a/website/docs/r/inventory.html.markdown
+++ b/website/docs/r/inventory.html.markdown
@@ -15,23 +15,27 @@ Manages DCNM inventory modules
 ```hcl
 resource "dcnm_inventory" "first" {
   fabric_name   = "fab2"
-  username      = "username for DCNM switches"
-  password      = "password for DCNM switches"
+  username      = "admin"
+  password      = "password"
   max_hops      = 0
   preserve_config = "false"
   auth_protocol = 0
-  config_timeout = 10
+  config_timeout = 15
   switch_config {
-    ip   = "switch IP"
+    ip   = "192.168.10.10"
     role = "leaf"
   }
   switch_config {
-    ip   = "switch IP"
+    ip   = "192.168.10.11"
+    role = "leaf"
+  }
+  switch_config {
+    ip   = "192.168.10.12"
+    role = "border"
+  }
+  switch_config {
+    ip   = "192.168.10.13"
     role = "spine"
-  }
-  switch_config {
-    ip   = "switch IP"
-    role = "leaf"
   }
 }
 ```
@@ -66,10 +70,4 @@ resource "dcnm_inventory" "first" {
 * `switch_config.mode` - Mode of the switch.
 
 ## Importing
-
-An existing switch inventory can be [imported][docs-import] into this resource via its fabric and name, using the following command:
-[docs-import]: https://www.terraform.io/docs/import/index.html
-
-```
-terraform import dcnm_inventory.example <fabric_name>:<switch_name>
-```
+`dcnm_inventory` does not support import in current version


### PR DESCRIPTION
a couple of change:
- There is no deterministic way to avoid the first Normal state of switch, wait for 10s in the code before checking the mode
- add a function to wait for the status of switches to become ok after rediscovering
- remove the config-preview step which is not useful
- change the update function to use a similar approach as create function, which is much faster
- update document to indicate import is not supported on dcnm_inventory
- update document examples

test done:
- adding switches to an empty fabric
- remove one switch
- destroy inventory
- add one switch to the existing config
- change the role of the existing config