### PR TITLE
Correct attachment response in dcnm_vrf and dcnm_network resources

### DIFF
--- a/dcnm/resource_dcnm_network.go
+++ b/dcnm/resource_dcnm_network.go
@@ -802,7 +802,7 @@ func resourceDCNMNetworkCreate(d *schema.ResourceData, m interface{}) error {
 
 			// Network Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
 					return fmt.Errorf("Network record is created but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1117,7 +1117,7 @@ func resourceDCNMNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 
 			// Network Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
 					return fmt.Errorf("Network record is updated but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1270,7 +1270,7 @@ func resourceDCNMNetworkDelete(d *schema.ResourceData, m interface{}) error {
 
 			// Network Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
 					return fmt.Errorf("Error while detachment : %s", v)
 				}
 			}

--- a/dcnm/resource_dcnm_network.go
+++ b/dcnm/resource_dcnm_network.go
@@ -802,7 +802,7 @@ func resourceDCNMNetworkCreate(d *schema.ResourceData, m interface{}) error {
 
 			// Network Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response -  SUCCESS" {
 					return fmt.Errorf("Network record is created but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1117,7 +1117,7 @@ func resourceDCNMNetworkUpdate(d *schema.ResourceData, m interface{}) error {
 
 			// Network Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response -  SUCCESS" {
 					return fmt.Errorf("Network record is updated but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1270,7 +1270,7 @@ func resourceDCNMNetworkDelete(d *schema.ResourceData, m interface{}) error {
 
 			// Network Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response -  SUCCESS" {
 					return fmt.Errorf("Error while detachment : %s", v)
 				}
 			}

--- a/dcnm/resource_dcnm_vrf.go
+++ b/dcnm/resource_dcnm_vrf.go
@@ -798,7 +798,7 @@ func resourceDCNMVRFCreate(d *schema.ResourceData, m interface{}) error {
 
 			// VRF Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response -  SUCCESS" {
 					return fmt.Errorf("VRF record is created but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1144,7 +1144,7 @@ func resourceDCNMVRFUpdate(d *schema.ResourceData, m interface{}) error {
 
 			// VRF Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response -  SUCCESS" {
 					return fmt.Errorf("VRF record is created but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1363,7 +1363,7 @@ func resourceDCNMVRFDelete(d *schema.ResourceData, m interface{}) error {
 
 			// VRF Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response -  SUCCESS" {
 					return fmt.Errorf("failure at the time of detachment : %s", v)
 				}
 			}

--- a/dcnm/resource_dcnm_vrf.go
+++ b/dcnm/resource_dcnm_vrf.go
@@ -798,7 +798,7 @@ func resourceDCNMVRFCreate(d *schema.ResourceData, m interface{}) error {
 
 			// VRF Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
 					return fmt.Errorf("VRF record is created but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1144,7 +1144,7 @@ func resourceDCNMVRFUpdate(d *schema.ResourceData, m interface{}) error {
 
 			// VRF Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
 					return fmt.Errorf("VRF record is created but not deployed yet. Error while attachment : %s", v)
 				}
 			}
@@ -1363,7 +1363,7 @@ func resourceDCNMVRFDelete(d *schema.ResourceData, m interface{}) error {
 
 			// VRF Deployment
 			for _, v := range cont.Data().(map[string]interface{}) {
-				if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
+				if v != "SUCCESS" && v != "SUCCESS Peer attach Response :  SUCCESS" {
 					return fmt.Errorf("failure at the time of detachment : %s", v)
 				}
 			}


### PR DESCRIPTION
I believe my issue with dcnm_vrf and dcnm_network resources in NDFC 12.1(3b) comes down to a simple spelling mistake.

The code is looking for   

```
                                 if v != "SUCCESS" && v != "SUCCESS Peer attach Reponse :  SUCCESS" {
					return fmt.Errorf("Error while detachment : %s", v)
				}
```

..while the actual word is "Response"

```
--[ HTTP Response ]----------------------------------- 
 HTTP/1.1 200 OK
Content-Length: 317
Cache-Control: no-cache, must-revalidate, proxy-revalidate, max-age=0
Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'self'; font-src 'self' data:; img-src 'self' data: alln-extcloud-storage.cisco.com; navigate-to *; worker-src 'self' blob:; connect-src 'self' wss:;
Content-Type: application/json
Date: Thu, 19 Oct 2023 08:33:57 GMT
Referrer-Policy: strict-origin-when-cross-origin
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Ratelimit-Limit: -1
X-Ratelimit-Remaining: -1
X-Ratelimit-Reset: 1559582945
X-Xss-Protection: 1; mode=block

{"TERRAFORM-VRF2-[97JYV3VMUXQ/DC1-LEAF4]-[97IMTL28HK8/DC1-LEAF3]":"SUCCESS Peer attach Response -  SUCCESS","TERRAFORM-VRF2-[9VUKIXRUG74/DC2-VBGW2]-[9053CEC6BAI/DC2-VBGW1]":"SUCCESS Peer attach Response -  SUCCESS","TERRAFORM-VRF2-[9QMRLH3A7V2/DC1-ABGW1]":"SUCCESS","TERRAFORM-VRF2-[9XQTWZZJ2VR/DC1-ABGW2]":"SUCCESS"}
```